### PR TITLE
Fix usage of private vars on RpcServer

### DIFF
--- a/dist/rpc/server/RpcServer.js
+++ b/dist/rpc/server/RpcServer.js
@@ -6,6 +6,12 @@ var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (
     privateMap.set(receiver, value);
     return value;
 };
+var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, privateMap) {
+    if (!privateMap.has(receiver)) {
+        throw new TypeError("attempted to get private field on non-instance");
+    }
+    return privateMap.get(receiver);
+};
 var _host, _port, _channel;
 Object.defineProperty(exports, "__esModule", { value: true });
 const structures_1 = require("../../clients/Api/structures");
@@ -46,7 +52,7 @@ class RpcServer extends grpc.Server {
                         console.error('server must be bound in order to start. maybe this host:port is already in use?');
                     }
                 }
-                const message = `Rpc server running at http://${this.host}:${this.port}`;
+                const message = `Rpc server running at http://${__classPrivateFieldGet(this, _host)}:${__classPrivateFieldGet(this, _port)}`;
                 this.emit('DEBUG', {
                     source: constants_1.LOG_SOURCES.RPC,
                     level: constants_1.LOG_LEVELS.INFO,
@@ -54,7 +60,7 @@ class RpcServer extends grpc.Server {
                 });
             }
         };
-        return [`${this.host}:${this.port}`, this.channel, callback];
+        return [`${__classPrivateFieldGet(this, _host)}:${__classPrivateFieldGet(this, _port)}`, __classPrivateFieldGet(this, _channel), callback];
     }
     addRequestService(token, apiOptions = {}) {
         services_1.addRequestService(this, token, apiOptions);

--- a/src/rpc/server/RpcServer.ts
+++ b/src/rpc/server/RpcServer.ts
@@ -77,7 +77,7 @@ export default class RpcServer extends grpc.Server {
           }
         }
 
-        const message = `Rpc server running at http://${this.host}:${this.port}`;
+        const message = `Rpc server running at http://${this.#host}:${this.#port}`;
         this.emit('DEBUG', {
           source: LOG_SOURCES.RPC,
           level: LOG_LEVELS.INFO,
@@ -86,7 +86,7 @@ export default class RpcServer extends grpc.Server {
       }
     };
 
-    return [`${this.host}:${this.port}`, this.channel, callback];
+    return [`${this.#host}:${this.#port}`, this.#channel, callback];
   }
 
   /**


### PR DESCRIPTION
### Summary
When I tried to check how rate limits work between processes I got this error:
```
/home/denis/js-workspace/paracord/node_modules/@grpc/grpc-js/src/server.ts:221
      throw new TypeError('creds must be an object');
            ^
TypeError: creds must be an object
    at RpcServer.bindAsync (/home/denis/js-workspace/paracord/node_modules/@grpc/grpc-js/src/server.ts:221:13)
    at RpcServer.serve (/home/denis/js-workspace/paracord/dist/rpc/server/RpcServer.js:70:14)
    at Object.<anonymous> (/home/denis/js-workspace/black-hole/src/rpc-server.ts:30:8)
    at Module._compile (internal/modules/cjs/loader.js:1176:30)
    at Module.m._compile (/home/denis/js-workspace/black-hole/node_modules/ts-node/src/index.ts:858:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1196:10)
    at Object.require.extensions.<computed> [as .ts] (/home/denis/js-workspace/black-hole/node_modules/ts-node/src/index.ts:861:12)
    at Module.load (internal/modules/cjs/loader.js:1040:32)
    at Function.Module._load (internal/modules/cjs/loader.js:929:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! threadrun@0.1.0 start-rpc: `node --inspect=5858 -r ts-node/register ./src/rpc-server.ts`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the threadrun@0.1.0 start-rpc script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/denis/.npm/_logs/2020-06-28T07_34_43_334Z-debug.log

```

This PR fixes this problem.

You can close this one if you fixed it on your branch already.

P.S. I noticed we have `dist` folder committed to the repo with generated build information. Should I send PR to remote that?